### PR TITLE
Add tests to ManageJenkinsTest on Search settings input field

### DIFF
--- a/src/test/java/school/redrover/ManageJenkinsTest.java
+++ b/src/test/java/school/redrover/ManageJenkinsTest.java
@@ -1,13 +1,16 @@
 package school.redrover;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import school.redrover.runner.BaseTest;
+import school.redrover.runner.ProjectUtils;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -20,7 +23,7 @@ public class ManageJenkinsTest extends BaseTest {
     public void testManageJenkinsTab() {
 
         List<WebElement> tasks = getDriver().findElements(
-                By.xpath("//div[@id='tasks']//a"));
+            By.xpath("//div[@id='tasks']//a"));
         Assert.assertEquals(tasks.size(), 1);
 
         List<String> expectedTexts = Arrays.asList("New Item", "Build History", "Manage Jenkins", "My Views");
@@ -30,7 +33,7 @@ public class ManageJenkinsTest extends BaseTest {
 
         WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
         WebElement manageJenkinsTask = wait.until(
-                ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]")));
+            ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]")));
         manageJenkinsTask.click();
 
     }
@@ -40,16 +43,16 @@ public class ManageJenkinsTest extends BaseTest {
 
         WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
         WebElement manageJenkinsTab = wait.until(
-                ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]"))
+            ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]"))
         );
         manageJenkinsTab.click();
 
         List<WebElement> sections = getDriver().findElements(
-                By.xpath("//h2[@class='jenkins-section__title']"));
+            By.xpath("//h2[@class='jenkins-section__title']"));
         Assert.assertEquals(sections.size(), 5);
 
         List<String> expectedSectionTitles = Arrays.asList(
-                "System Configuration", "Security", "Status Information", "Troubleshooting", "Tools and Actions"
+            "System Configuration", "Security", "Status Information", "Troubleshooting", "Tools and Actions"
         );
         for (int i = 0; i < expectedSectionTitles.size(); i++) {
             Assert.assertEquals(sections.get(i).getText(), expectedSectionTitles.get(i));
@@ -60,7 +63,7 @@ public class ManageJenkinsTest extends BaseTest {
     @Test
     public void testManageJenkinsSections() {
         final List<String> expectedSectionsTitles = List.of("System Configuration", "Security", "Status Information",
-                "Troubleshooting", "Tools and Actions");
+            "Troubleshooting", "Tools and Actions");
 
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
 
@@ -73,12 +76,12 @@ public class ManageJenkinsTest extends BaseTest {
     @Test
     public void testManageJenkinsSystemConfigurationItems() {
         final List<String> expectedItemsNames = List.of("System", "Tools", "Plugins",
-                "Nodes", "Clouds", "Appearance");
+            "Nodes", "Clouds", "Appearance");
 
         getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
 
         List<WebElement> systemConfigItems = getDriver()
-                .findElements(By.xpath("(//div[@class='jenkins-section__items'])[1]//dt"));
+                                                 .findElements(By.xpath("(//div[@class='jenkins-section__items'])[1]//dt"));
         List<String> actualItemsNames = systemConfigItems.stream().map(WebElement::getText).toList();
 
         Assert.assertEquals(actualItemsNames, expectedItemsNames);
@@ -102,12 +105,12 @@ public class ManageJenkinsTest extends BaseTest {
 
         WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
         WebElement manageJenkinsTab = wait.until(
-                ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]"))
+            ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]"))
         );
         manageJenkinsTab.click();
 
         WebElement searchField = getDriver().findElement(
-                By.xpath("//input[@id='settings-search-bar']"));
+            By.xpath("//input[@id='settings-search-bar']"));
         Assert.assertEquals(searchField.getAttribute("placeholder"), "Search settings");
 
     }
@@ -117,23 +120,90 @@ public class ManageJenkinsTest extends BaseTest {
 
         WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
         WebElement manageJenkinsTab = wait.until(
-                ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]")));
+            ExpectedConditions.elementToBeClickable(By.xpath("//a[span[text()='Manage Jenkins']]")));
         manageJenkinsTab.click();
 
         WebElement searchField = getDriver().findElement(
-                By.xpath("//input[@id='settings-search-bar']"));
+            By.xpath("//input[@id='settings-search-bar']"));
 
         List<String> itemsSystemConfiguration = Arrays.asList(
-                "System", "Tools", "Plugins", "Nodes", "Clouds", "Appearance");
+            "System", "Tools", "Plugins", "Nodes", "Clouds", "Appearance");
         for (String itemsSystemConfigurations : itemsSystemConfiguration) {
             wait.until(ExpectedConditions.elementToBeClickable(searchField)).clear();
             wait.until(ExpectedConditions.visibilityOf(searchField)).sendKeys(itemsSystemConfigurations);
 
             WebElement searchDropdown = wait.until(
-                    ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='jenkins-search__results']")));
+                ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='jenkins-search__results']")));
 
             Assert.assertNotNull(searchDropdown, "Item '" + itemsSystemConfigurations + "' not found in dropdown.");
 
         }
+    }
+
+    @Test
+    public void testSearchSettingsWithNoResult() {
+        WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(5));
+
+        getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
+
+        getDriver().findElement(By.cssSelector("input[id=settings-search-bar]")).sendKeys("1333");
+
+        WebElement noResultLabel = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[class$='no-results-label']")));
+
+        String actualNoResultText = noResultLabel.getText();
+
+        Assert.assertEquals(actualNoResultText, "No results");
+    }
+
+    @Test
+    public void testRedirectToFirstItemAfterPressEnter() {
+
+        WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(5));
+
+        getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
+
+        WebElement searchSettingInput = getDriver().findElement(By.cssSelector("input[id=settings-search-bar]"));
+
+        searchSettingInput.sendKeys("c");
+
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("jenkins-search__results-item--selected")));
+
+        searchSettingInput.sendKeys(Keys.ENTER);
+
+        String actualURL = getDriver().getCurrentUrl();
+
+        Assert.assertEquals(actualURL, ProjectUtils.getUrl() + "manage/cloud/");
+    }
+
+    @Test
+    public void testSearchSettingTooltip() {
+
+        WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(5));
+
+        getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
+
+        WebElement tooltip = getDriver().findElement(By.cssSelector("[class='jenkins-search__shortcut']"));
+
+        Actions actions = new Actions(getDriver());
+        actions.moveToElement(tooltip).perform();
+
+        WebElement tooltipHiddenAttribute = wait.until(ExpectedConditions
+                                                           .visibilityOfElementLocated(By.xpath("//div[@aria-describedby='tippy-6']")));
+
+        Assert.assertTrue(tooltipHiddenAttribute.isDisplayed());
+    }
+
+    @Test
+    public void testShortcutMovesFocusToSearchSettingsField() {
+        final String expectedTextInSearchSettingsField = "123456";
+
+        getDriver().findElement(By.xpath("//a[@href='/manage']")).click();
+
+        Actions actions = new Actions(getDriver());
+        actions.sendKeys(Keys.chord("/", expectedTextInSearchSettingsField)).perform();
+
+        String actualTextInSearchSettingsField = getDriver().findElement(By.cssSelector("input[id = 'settings-search-bar']")).getAttribute("value");
+
+        Assert.assertEquals(actualTextInSearchSettingsField, expectedTextInSearchSettingsField);
     }
 }


### PR DESCRIPTION
Added tests:
1. Check 'No results' message appears for an empty search result.
2. Verify redirection to the first search result when pressing Enter.
3. Visibility of search settings tooltip.
4. Check if shortcut ("/") works correctly.