### PR TITLE
Added tests for Jenkins version > AT_12.001.01 and AT_12.001.02

### DIFF
--- a/src/test/java/school/redrover/VersionTest.java
+++ b/src/test/java/school/redrover/VersionTest.java
@@ -5,8 +5,14 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import school.redrover.page.HomePage;
 import school.redrover.runner.BaseTest;
+
 public class VersionTest extends BaseTest {
+
+    private static final String EXPECTED_JENKINS_VERSION = "Jenkins 2.462.3";
+    private static final String ABOUT_JENKINS_LABEL = "About Jenkins";
+
     @Test
     public void CheckVersionTest() {
 
@@ -25,4 +31,20 @@ public class VersionTest extends BaseTest {
 
     }
 
+    @Test
+    public void testJenkinsVersionOnDashboard() {
+        String currentJenkinsVersion = new HomePage(getDriver())
+                .getJenkinsVersion();
+
+        Assert.assertEquals(currentJenkinsVersion, EXPECTED_JENKINS_VERSION);
+    }
+
+    @Test
+    public void testJenkinsLabelInDropdown() {
+        String actualButtonLabel = new HomePage(getDriver())
+                .clickJenkinsVersionButton()
+                .getAboutJenkinsDropdownLabelText();
+
+        Assert.assertEquals(actualButtonLabel, ABOUT_JENKINS_LABEL);
+    }
 }

--- a/src/test/java/school/redrover/page/HomePage.java
+++ b/src/test/java/school/redrover/page/HomePage.java
@@ -381,4 +381,19 @@ public class HomePage extends BasePage {
 
         return new NewViewPage(getDriver());
     }
+
+    public String getJenkinsVersion() {
+        return getDriver().findElement(By.cssSelector("[class$='jenkins_ver']")).getText();
+    }
+
+    public HomePage clickJenkinsVersionButton() {
+        getDriver().findElement(By.cssSelector("[class$='jenkins_ver']")).click();
+
+        return this;
+    }
+
+    public String getAboutJenkinsDropdownLabelText() {
+        return getWait2().until(ExpectedConditions.visibilityOfElementLocated(
+                By.cssSelector("[href='/manage/about']"))).getText();
+    }
 }


### PR DESCRIPTION
[AT_12.001.01 | Footer > Jenkins version > Verify the current Jenkins version number in the footer of the Jenkins dashboard.](https://github.com/RedRoverSchool/JenkinsQA_2024_fall/issues/1061)
and
[AT_12.001.02 | Footer > Jenkins version > Verify version button clickability and display of "About Jenkins" in dropdown menu.](https://github.com/RedRoverSchool/JenkinsQA_2024_fall/issues/1062)