### PR TITLE
add gson, FolderResponse class, ProjectListResponse class

### DIFF
--- a/src/test/java/school/redrover/APIHTTPFolderTest.java
+++ b/src/test/java/school/redrover/APIHTTPFolderTest.java
@@ -8,7 +8,7 @@ import io.qameta.allure.Epic;
 import io.qameta.allure.Story;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import school.redrover.model.FolderResponse;
+import school.redrover.model.ProjectResponse;
 import school.redrover.model.ProjectListResponse;
 import school.redrover.runner.BaseAPIHttpTest;
 import school.redrover.runner.ProjectUtils;
@@ -22,7 +22,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 @Epic("Http API Requests")
 public class APIHTTPFolderTest extends BaseAPIHttpTest {
@@ -79,14 +78,14 @@ public class APIHTTPFolderTest extends BaseAPIHttpTest {
         Allure.step("Expected result: Created element is found by name");
         Assert.assertEquals(getResponse.statusCode(), 200);
 
-        FolderResponse folderResponse = new Gson().fromJson(body, FolderResponse.class);
+        ProjectResponse projectResponse = new Gson().fromJson(body, ProjectResponse.class);
         Allure.step(String.format("Expected result: fullName is '%s' response", FOLDER_NAME));
-        Assert.assertEquals(folderResponse.getFullName(), FOLDER_NAME);
+        Assert.assertEquals(projectResponse.getFullName(), FOLDER_NAME);
 
         Allure.step("Expected result: description is null");
-        Assert.assertNull(folderResponse.getDescription());
+        Assert.assertNull(projectResponse.getDescription());
 
-        Assert.assertEquals(folderResponse.get_class(),FOLDER_CREATE_MODE);
+        Assert.assertEquals(projectResponse.get_class(),FOLDER_CREATE_MODE);
     }
 
     @Test(dependsOnMethods = "testCreateFolderWithValidName")
@@ -167,9 +166,9 @@ public class APIHTTPFolderTest extends BaseAPIHttpTest {
         HttpResponse<String> getItemByNameResponse = httpClient.send(getItemByNameRequest, HttpResponse.BodyHandlers.ofString());
         String body = getItemByNameResponse.body();
 
-        FolderResponse folderResponse = new Gson().fromJson(body, FolderResponse.class);
+        ProjectResponse projectResponse = new Gson().fromJson(body, ProjectResponse.class);
         Allure.step("(ERR)Expected result: Response body contains 'description: null' for folder");
-        Assert.assertNull(folderResponse.getDescription());
+        Assert.assertNull(projectResponse.getDescription());
 
         HttpRequest deleteRequest = HttpRequest.newBuilder()
                 .uri(new URI(getDeleteItemURL(FOLDER_NAME)))

--- a/src/test/java/school/redrover/APIHttpTest.java
+++ b/src/test/java/school/redrover/APIHttpTest.java
@@ -18,14 +18,16 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import school.redrover.model.FolderResponse;
+import school.redrover.model.ProjectListResponse;
 import school.redrover.runner.BaseAPIHttpTest;
 import school.redrover.runner.ProjectUtils;
 import school.redrover.runner.TestUtils;
 
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Epic("Http API  Requests")
@@ -70,6 +72,34 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
 
     private List<String> getAllProjectViewNamesFromJsonResponseList() throws IOException {
         return getProjectNamesFromJsonResponseList(ProjectUtils.getUrl() + API_JSON_URL, "views");
+    }
+
+    private String getCreateItemBody(String name, String mode) {
+        return "name=" + TestUtils.encodeParam(name) + "&mode=" + mode;
+    }
+
+    private String getRenameItemBody(String name) {
+        return "newName=" + TestUtils.encodeParam(name);
+    }
+
+    private String getAddDescriptionBody(String description) {
+        return "description=" + TestUtils.encodeParam(description);
+
+    }
+    private String getItemByNameURL(String name) {
+        return ProjectUtils.getUrl() + String.format("job/%s/api/json", TestUtils.encodeParam(name));
+    }
+
+    private String getCreateItemURL() {
+        return ProjectUtils.getUrl() + "createItem";
+    }
+
+    private String getRenameItemURL(String name) {
+        return ProjectUtils.getUrl() + String.format("job/%s/confirmRename", TestUtils.encodeParam(name));
+    }
+
+    private String getAddDescriptionURL(String name) {
+        return ProjectUtils.getUrl() + String.format("job/%s/submitDescription",TestUtils.encodeParam(name));
     }
 
     @Test
@@ -269,23 +299,35 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
                         "The folder is not created");
             }
 
-            HttpGet httpGet = new HttpGet(String.format(ProjectUtils.getUrl() + "job/%s/api/json", FOLDER_NAME_BY_XML_CREATED));
+            HttpGet httpGet = new HttpGet(getItemByNameURL(FOLDER_NAME_BY_XML_CREATED));
             httpGet.addHeader("Authorization", getBasicAuthWithToken());
 
             Allure.step("Send GET request -> Get item by name");
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
                 String responseBody = EntityUtils.toString(response.getEntity());
-                JSONObject jsonResponse = new JSONObject(responseBody);
-                String actualFullName = jsonResponse.getString("fullName");
+
+                FolderResponse folderResponse = new Gson().fromJson(responseBody, FolderResponse.class);
 
                 Allure.step("Expected result: Status code is 200");
                 Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
 
                 Allure.step("Expected result: fullName in json is " + FOLDER_NAME_BY_XML_CREATED);
-                Assert.assertEquals(FOLDER_NAME_BY_XML_CREATED, actualFullName, "Folder didn't find");
+                Assert.assertEquals(folderResponse.getFullName(), FOLDER_NAME_BY_XML_CREATED, "Folder didn't find");
 
-                Allure.step("Expected result: Header 'Content-Type : application/json;charset=utf-8' ");
-                Assert.assertEquals(response.getFirstHeader("Content-Type").getValue(), "application/json;charset=utf-8");
+                Allure.step("Send GET request -> Get project list from Dashboard");
+                HttpGet getItemList = new HttpGet(ProjectUtils.getUrl() + "api/json");
+                getItemList.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
+                try (CloseableHttpResponse getItemListResponse = httpClient.execute(getItemList)) {
+                    String getItemListResponseBody = EntityUtils.toString(getItemListResponse.getEntity());
+                    ProjectListResponse projectListResponse = new Gson().fromJson(getItemListResponseBody, ProjectListResponse.class);
+
+                    boolean findFolderNameInProjectList = projectListResponse.getJobs()
+                            .stream().anyMatch(project -> project.getName().equals(FOLDER_NAME_BY_XML_CREATED));
+
+                    Allure.step("Expected result: Project name found in the list");
+                    Assert.assertTrue(findFolderNameInProjectList, "Project name was not found in the list");
+                }
             }
         }
     }
@@ -294,49 +336,67 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
     @Story("Folder")
     @Description("002 Create Folder with valid name")
     public void testCreateFolderWithValidName() throws IOException {
-        try (CloseableHttpClient httpClient = createHttpClientWithAllureLogging()) {
+            try (CloseableHttpClient httpClient = createHttpClientWithAllureLogging()) {
 
-            HttpPost postCreateItem = new HttpPost(ProjectUtils.getUrl() + "createItem");
-            postCreateItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
-            postCreateItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
-            postCreateItem.setEntity(new StringEntity("name=" + FOLDER_NAME + "&mode=" + FOLDER_MODE));
+                Allure.step("Send POST request -> Create Folder");
+                HttpPost postCreateItem = new HttpPost(getCreateItemURL());
+                postCreateItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+                postCreateItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+                postCreateItem.setEntity(new StringEntity(getCreateItemBody(FOLDER_NAME, FOLDER_MODE)));
 
-            Allure.step("Send POST request -> Create Folder");
-            try (CloseableHttpResponse postCreateItemResponse = httpClient.execute(postCreateItem)) {
-                Allure.step("Expected result: Successful item creation. Status code 302");
-                Assert.assertEquals(postCreateItemResponse.getStatusLine().getStatusCode(), 302);
-            }
+                try (CloseableHttpResponse postCreateItemResponse = httpClient.execute(postCreateItem)) {
+                    Allure.step("Expected result: Successful item creation. Status code 302");
+                    Assert.assertEquals(postCreateItemResponse.getStatusLine().getStatusCode(), 302);
+                }
 
-            Allure.step("Send GET request -> Get item by name");
-            HttpGet getItemByName = new HttpGet(ProjectUtils.getUrl() +
-                    String.format("job/%s", URLEncoder.encode(FOLDER_NAME, StandardCharsets.UTF_8)) + "/api/json");
-            getItemByName.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
-            try (CloseableHttpResponse getItemByNameResponse = httpClient.execute(getItemByName)) {
-                Allure.step("Expected result: Created element is found by name");
-                Assert.assertEquals(getItemByNameResponse.getStatusLine().getStatusCode(), 200);
+                Allure.step("Send GET request -> Get item by name");
+                HttpGet getItemByName = new HttpGet(getItemByNameURL(FOLDER_NAME));
+                getItemByName.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
 
-                String jsonResponse = EntityUtils.toString(getItemByNameResponse.getEntity());
+                try (CloseableHttpResponse getItemByNameResponse = httpClient.execute(getItemByName)) {
+                    Allure.step("Expected result: Created element is found by name");
+                    Assert.assertEquals(getItemByNameResponse.getStatusLine().getStatusCode(), 200);
 
-                Allure.step(String.format("Expected result: fullName is '%s' response", FOLDER_NAME));
-                Assert.assertTrue(jsonResponse.contains(String.format("\"fullName\":\"%s\"", FOLDER_NAME)), "Folder not found");
-                Allure.step("Expected result: description is null");
-                Assert.assertTrue(jsonResponse.contains("\"description\":null"));
+                    String jsonResponse = EntityUtils.toString(getItemByNameResponse.getEntity());
+                    FolderResponse folderResponse = new Gson().fromJson(jsonResponse, FolderResponse.class);
+
+                    Allure.step(String.format("Expected result: fullName is '%s' response", FOLDER_NAME));
+                    Assert.assertEquals(folderResponse.getFullName(), FOLDER_NAME, "Folder didn't find");
+                    Allure.step("Expected result: description is null");
+                    Assert.assertNull(folderResponse.getDescription());
+                    Allure.step(String.format("Expected result: Field '_class': %s", FOLDER_MODE));
+                    Assert.assertEquals(folderResponse.get_class(), FOLDER_MODE);
+
+                    Allure.step("Send GET request -> Get project list from Dashboard");
+                    HttpGet getItemList = new HttpGet(ProjectUtils.getUrl() + "api/json");
+                    getItemList.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
+                    try (CloseableHttpResponse getItemListResponse = httpClient.execute(getItemList)) {
+                        String getItemListResponseBody = EntityUtils.toString(getItemListResponse.getEntity());
+                        ProjectListResponse projectListResponse = new Gson().fromJson(getItemListResponseBody, ProjectListResponse.class);
+
+                        boolean findFolderNameInProjectList = projectListResponse.getJobs()
+                                .stream().anyMatch(project -> project.getName().equals(FOLDER_NAME));
+
+                        Allure.step("Expected result: Project name found in the list");
+                        Assert.assertTrue(findFolderNameInProjectList, "Project name was not found in the list");
+                    }
+                }
             }
         }
-    }
 
     @Test(dependsOnMethods = "testCreateFolderWithValidName")
     @Story("Folder")
     @Description("008 Rename Folder")
     public void testRenameFolder() throws IOException {
         try (CloseableHttpClient httpClient = createHttpClientWithAllureLogging()) {
-            HttpPost postRenameItem = new HttpPost(ProjectUtils.getUrl() +
-                    String.format("job/%s/confirmRename", TestUtils.encodeParam(FOLDER_NAME)));
-            postRenameItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
-            postRenameItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
-            postRenameItem.setEntity(new StringEntity("newName=" + TestUtils.encodeParam(FOLDER_NEW_NAME)));
 
             Allure.step("Send POST request -> Rename Folder");
+            HttpPost postRenameItem = new HttpPost(getRenameItemURL(FOLDER_NAME));
+            postRenameItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+            postRenameItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+            postRenameItem.setEntity(new StringEntity(getRenameItemBody(FOLDER_NEW_NAME)));
+
             try (CloseableHttpResponse postRenameItemResponse = httpClient.execute(postRenameItem)) {
                 Allure.step("Expected result: Item renamed successful. Status code 302");
                 Assert.assertEquals(postRenameItemResponse.getStatusLine().getStatusCode(), 302);
@@ -354,44 +414,49 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
         String description = "Add description to folder!";
         try (CloseableHttpClient httpClient = createHttpClientWithAllureLogging()) {
 
-            HttpPost postCreateItem = new HttpPost(ProjectUtils.getUrl() + "createItem");
+            Allure.step("Send POST request -> Create Folder");
+            HttpPost postCreateItem = new HttpPost(getCreateItemURL());
             postCreateItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
             postCreateItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
-            postCreateItem.setEntity(new StringEntity("name=" + FOLDER_NAME + "&mode=" + FOLDER_MODE));
+            postCreateItem.setEntity(new StringEntity(getCreateItemBody(FOLDER_NAME, FOLDER_MODE)));
 
-            Allure.step("Send POST request -> Create Folder");
             try (CloseableHttpResponse postCreateItemResponse = httpClient.execute(postCreateItem)) {
                 Allure.step("Expected result: Successful item creation. Status code 302");
                 Assert.assertEquals(postCreateItemResponse.getStatusLine().getStatusCode(), 302);
             }
 
-            HttpPost postAddDescriptionItem = new HttpPost(ProjectUtils.getUrl() +
-                    String.format("job/%s/submitDescription", TestUtils.encodeParam(FOLDER_NAME)));
+            Allure.step("Send POST request -> Add Description to Folder");
+            HttpPost postAddDescriptionItem = new HttpPost(getAddDescriptionURL(FOLDER_NAME));
             postAddDescriptionItem.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
             postAddDescriptionItem.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
-            postAddDescriptionItem.setEntity(new StringEntity("description=" + TestUtils.encodeParam(description)));
+            postAddDescriptionItem.setEntity(new StringEntity(getAddDescriptionBody(description)));
 
-            Allure.step("Send POST request -> Add Description to Folder");
             try (CloseableHttpResponse postAddDescriptionResponse = httpClient.execute(postAddDescriptionItem)) {
                 Allure.step("Expected result: Successful add description to item. Status code 302");
                 Assert.assertEquals(postAddDescriptionResponse.getStatusLine().getStatusCode(), 302);
             }
 
             Allure.step("Send GET request -> Get item by name");
-            HttpGet getItemByName = new HttpGet(ProjectUtils.getUrl() +
-                    String.format("job/%s", TestUtils.encodeParam(FOLDER_NAME)) + "/api/json");
+            HttpGet getItemByName = new HttpGet(getItemByNameURL(FOLDER_NAME));
             getItemByName.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
             try (CloseableHttpResponse getItemByNameResponse = httpClient.execute(getItemByName)) {
                 Allure.step("Expected result: Created element is found by name");
                 Assert.assertEquals(getItemByNameResponse.getStatusLine().getStatusCode(), 200);
 
                 String jsonResponse = EntityUtils.toString(getItemByNameResponse.getEntity());
-                Allure.step("Expected result: Response body contains 'description: null' for folder(ERR)");
-                Assert.assertTrue(jsonResponse.contains("\"description\":null"), "Description is not null");
+
+                FolderResponse folderResponse = new Gson().fromJson(jsonResponse, FolderResponse.class);
+
+                Allure.step(String.format("(ERR) Expected result: description is '%s'",description));
+                Assert.assertNull(folderResponse.getDescription());
+
             }
+
             Allure.step("Send DELETE request -> Delete Folder");
             HttpDelete deleteFolder = new HttpDelete(ProjectUtils.getUrl() + String.format("job/%s/", TestUtils.encodeParam(FOLDER_NAME)));
             deleteFolder.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
             try (CloseableHttpResponse deleteFolderResponse = httpClient.execute(deleteFolder)) {
                 Allure.step("Expected result: Delete item successful. Status code is 204");
                 Assert.assertEquals(deleteFolderResponse.getStatusLine().getStatusCode(), 204);
@@ -405,10 +470,10 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
     public void testDeleteFolder() throws IOException {
         try (CloseableHttpClient httpClient = createHttpClientWithAllureLogging()) {
 
+            Allure.step("Send DELETE request -> Delete Folder");
             HttpDelete httpDelete = new HttpDelete(String.format(ProjectUtils.getUrl() + "job/%s/", FOLDER_NAME_BY_XML_CREATED));
             httpDelete.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
 
-            Allure.step("Send DELETE request -> Delete Folder");
             try (CloseableHttpResponse response = httpClient.execute(httpDelete)) {
 
                 Allure.step("Expected result: Delete item status code is 204");
@@ -418,10 +483,11 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
                 Assert.assertListNotContainsObject(getAllProjectNamesFromJsonResponseList(), FOLDER_NAME_BY_XML_CREATED,
                         "The folder is not deleted");
             }
-            HttpGet httpGet = new HttpGet(String.format(ProjectUtils.getUrl() + "job/%s/api/json", FOLDER_NAME_BY_XML_CREATED));
-            httpGet.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
 
             Allure.step("Send GET request -> Get item by name");
+            HttpGet httpGet = new HttpGet(getItemByNameURL(FOLDER_NAME_BY_XML_CREATED));
+            httpGet.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
 
                 Allure.step("Expected result: Item not found. Status code is 404");

--- a/src/test/java/school/redrover/APIHttpTest.java
+++ b/src/test/java/school/redrover/APIHttpTest.java
@@ -712,7 +712,21 @@ public class APIHttpTest extends BaseAPIHttpTest {  // Using Apache HttpClient
                 Allure.step(String.format("Expected result: Field '_class': %s", MULTICONFIGURATION_MODE));
                 Assert.assertEquals(projectResponse.get_class(), MULTICONFIGURATION_MODE);
             }
-        }
 
+            Allure.step("Send GET request -> Get project list from Dashboard");
+            HttpGet getItemList = new HttpGet(ProjectUtils.getUrl() + "api/json");
+            getItemList.addHeader(HttpHeaders.AUTHORIZATION, getBasicAuthWithToken());
+
+            try (CloseableHttpResponse getItemListResponse = httpClient.execute(getItemList)) {
+                String getItemListResponseBody = EntityUtils.toString(getItemListResponse.getEntity());
+                ProjectListResponse projectListResponse = new Gson().fromJson(getItemListResponseBody, ProjectListResponse.class);
+
+                boolean findFolderNameInProjectList = projectListResponse.getJobs()
+                        .stream().anyMatch(project -> project.getName().equals(MULTICONFIGURATION_NAME));
+
+                Allure.step("Expected result: Project name found in the list");
+                Assert.assertTrue(findFolderNameInProjectList, "Project name was not found in the list");
+            }
+        }
     }
 }

--- a/src/test/java/school/redrover/model/FolderResponse.java
+++ b/src/test/java/school/redrover/model/FolderResponse.java
@@ -1,0 +1,23 @@
+package school.redrover.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FolderResponse {
+    private String _class;
+    private String description;
+    private String displayName;
+    private String displayNameOrNull;
+    private String fullDisplayName;
+    private String fullName;
+    private String name;
+    private String url;
+}
+
+

--- a/src/test/java/school/redrover/model/ProjectListResponse.java
+++ b/src/test/java/school/redrover/model/ProjectListResponse.java
@@ -1,0 +1,31 @@
+package school.redrover.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProjectListResponse {
+    @JsonProperty("_class")
+    private String classField;
+    private List<Project> jobs;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Project {
+        @JsonProperty("_class")
+        private String classField;
+        private String name;
+        private String url;
+    }
+}
+

--- a/src/test/java/school/redrover/model/ProjectResponse.java
+++ b/src/test/java/school/redrover/model/ProjectResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FolderResponse {
+public class ProjectResponse {
     private String _class;
     private String description;
     private String displayName;


### PR DESCRIPTION
I added the classes as best I could by  analogy  with FreestyleResponse, but I couldn't wrap the _class field with JsonProperty("_class"). In my checks, getClassField() was returning null.

- add ProjectResponse class -> class with the main fields from the response when requesting a specific project
- add ProjectListREsponse -> class with the fields when requesting a list of all projects

I think these methods can be moved to a common class. But which one would be better?
- add getCreateItemURL,  getCreateItemBody
-  add getRenameItemURL,  getRenameItemBody
- add getAddDescriptionURL, getAddDescriptionBody
- add getItemByNameURL